### PR TITLE
chore: GitHub Actions の SHA ピン留めと Dependabot cooldown 設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,14 @@ updates:
     directory: "./app" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
   - package-ecosystem: "docker"
     directory: "./app"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     groups:
       docker-dependencies:
         patterns:
@@ -21,6 +25,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 14
     groups:
       workflow-dependencies:
         patterns:

--- a/.github/workflows/docker_image_ci.yml
+++ b/.github/workflows/docker_image_ci.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Build the Docker image
         run: |
           cd app

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,9 +4,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
       - name: Install dependencies


### PR DESCRIPTION
## 実装経緯の説明

サプライチェーン攻撃対策として、GitHub Actions の外部 Action をタグ参照からコミット SHA 参照に切り替え、Dependabot にクールダウン期間を設定した。タグは付け替えが可能なため、タグ参照のままだと上流リポジトリが侵害された際に悪意あるコードが CI に混入するリスクがある。また、クールダウンにより侵害されたバージョンがリリース直後に自動更新 PR 経由で取り込まれるのを防ぐ。

## 補足

### 主な変更内容

- `actions/checkout@v7` → `9c091bb… # v7.0.0` に SHA ピン留め（docker_image_ci.yml / lint_python.yml の 2 箇所）
- `actions/setup-python@v6` → `ece7cb0… # v6.3.0` に SHA ピン留め
- `dependabot.yml` の全エコシステム（pip / docker / github-actions）に `cooldown: default-days: 14` を追加

### 技術的な詳細

- ピン留めは [pinact](https://github.com/suzuki-shunsuke/pinact) で実施し、`pinact run --verify` で SHA とタグの整合性を確認済み
- ピン留めしたバージョンはいずれもリリースから 2 週間以上経過（checkout v7.0.0: 2026-06-18、setup-python v6.3.0: 2026-06-24）
- prettier によるフォーマットチェック済み

### 確認事項

- 両ワークフロー（Docker Image CI / Lint Python）が PR 上で正常に走ること
- 今後の Dependabot 更新 PR がリリース 14 日経過後に作成されるようになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)