### PR TITLE
fix: ワークフローにGITHUB_TOKENの最小権限を設定

### DIFF
--- a/.github/workflows/docker_image_ci.yml
+++ b/.github/workflows/docker_image_ci.yml
@@ -8,6 +8,9 @@ on:
       - app/uv.lock
       - .github/workflows/docker_image_ci.yml
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,5 +1,7 @@
 name: CI
 on: push
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 実装経緯の説明

CodeQLのcode scanningアラート（`actions/missing-workflow-permissions`、severity: medium）が2件開いていた。ワークフローに `permissions` ブロックがなく、`GITHUB_TOKEN` がデフォルトの広い権限で発行されていたため、最小権限を明示して解消する。

- https://github.com/hodanov/stable-diffusion-cli-on-modal/security/code-scanning/7
- https://github.com/hodanov/stable-diffusion-cli-on-modal/security/code-scanning/8

## 補足

### 主な変更内容

- `.github/workflows/docker_image_ci.yml`: トップレベルに `permissions: contents: read` を追加
- `.github/workflows/lint_python.yml`: 同上

### 技術的な詳細

- どちらのワークフローもcheckoutしてdocker build / ruffを実行するだけで、トークンによる書き込み操作は行わないため、リポジトリ読み取り権限のみで動作する
- CodeQLが提案する最小権限（`contents: read`）をそのまま採用

### 確認事項

- マージ後、Securityタブのcode scanningアラート2件が自動クローズされること
- 両ワークフロー（Docker image CI / CI）がこのPR上で正常に完走すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)