### PR TITLE
build: DockerfileにhadolintをCI導入し、apt-get依存を撤廃

### DIFF
--- a/.github/workflows/docker_image_ci.yml
+++ b/.github/workflows/docker_image_ci.yml
@@ -12,6 +12,13 @@ permissions:
   contents: read
 
 jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: app/Dockerfile
   build:
     runs-on: ubuntu-latest
     steps:

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,10 +1,6 @@
 FROM python:3.14.6-slim-bookworm
 COPY --from=ghcr.io/astral-sh/uv:0.11.24 /uv /uvx /usr/local/bin/
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
+WORKDIR /app
 COPY ./pyproject.toml ./uv.lock ./
-RUN apt-get update \
-    && apt-get install wget git libgl1-mesa-glx libglib2.0-0 --no-install-recommends -y \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && uv sync --frozen --no-dev --no-cache
+RUN uv sync --frozen --no-dev --no-cache

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "imageio",
   "imageio-ffmpeg",
   "invisible-watermark",  # To help viewers identify the images as machine-generated.
+  "opencv-python-headless",  # Replaces the GUI build of opencv-python so the image needs no apt-installed libGL/libglib.
   "peft",
   "pillow",
   "pillow-avif-plugin",  # To save images in AVIF format.
@@ -22,6 +23,10 @@ dependencies = [
 
 [tool.uv]
 package = false
+override-dependencies = [
+  # Exclude the GUI build of opencv pulled in by invisible-watermark; opencv-python-headless provides cv2 instead.
+  "opencv-python; sys_platform == 'never'",
+]
 
 [[tool.uv.index]]
 name = "pytorch-cu126"

--- a/app/uv.lock
+++ b/app/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = "==3.14.*"
 
+[manifest]
+overrides = [{ name = "opencv-python", marker = "sys_platform == 'never'" }]
+
 [[package]]
 name = "accelerate"
 version = "1.14.0"
@@ -394,7 +397,7 @@ version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "opencv-python" },
+    { name = "opencv-python", marker = "sys_platform == 'never'" },
     { name = "pillow" },
     { name = "pywavelets" },
     { name = "torch" },
@@ -696,16 +699,6 @@ dependencies = [
     { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/75/76f6ade78f6102c61034f828e2a22616708df2c9504bc8d6af9dd8f73dc5/opencv_python-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:198a75138241810206a17c829dbcc40a7cb1841cda538ca86cbbfc6c7d95f898", size = 48322443, upload-time = "2026-07-02T05:50:25.466Z" },
-    { url = "https://files.pythonhosted.org/packages/15/8c/bc1bda6aae69a32e9d84fc34153ba104cd25226861eb4aea33b2cea4860d/opencv_python-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:6bbc32f59e1b1a7db7b39c81f63d00625f041d333037fd8702f6da52cc39108b", size = 34782755, upload-time = "2026-07-02T05:51:30.556Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/8a/b04776ec45d2dea08a1b176f1829201db3515d4ed16c35f8fcc9fa7beb16/opencv_python-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2b4272e736836f66c2d176e43ab8101f3a00d45654916399f52e150c58981ac", size = 50614064, upload-time = "2026-07-02T06:53:22.604Z" },
-    { url = "https://files.pythonhosted.org/packages/95/54/eb47866b94f2b5b42dde17644b78055ef1ee05aae59962c7290e55270803/opencv_python-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8b6d0a212253dd26ad338c812f1f23ca118fdf05a9c8c6b9444f161aa8c5881", size = 71064711, upload-time = "2026-07-02T06:54:13.148Z" },
-    { url = "https://files.pythonhosted.org/packages/93/da/962579f1e703cbf8c5422fd1f576467dcb3b5b0b0b81c1471c979764353a/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:08d5d91d967b58d6db86073b2ad3eaef88ca4ebdfd45c9059bf59f5ded0c7ad2", size = 49798576, upload-time = "2026-07-02T06:54:33.781Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/4c/c73f828fdbcd37eaf21d08fa852544a3ca7c2dbb3ea76873d64f2ea413d1/opencv_python-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c8de2dec111122a02e8beb28e16c31904992dfd6186560b142a92c71403c1039", size = 73783032, upload-time = "2026-07-02T06:55:03.415Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/4b/edaf83b996ca5a1a3d8ccad485706b9c6d4742b13b9c4586bf1c1e7d9423/opencv_python-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:4b4b1a34c79bf8d3738e3cfe9a9e67b51a79663f6b692cbdad8c31f570da4157", size = 35564734, upload-time = "2026-07-02T05:49:57.704Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f0/9fa6e85cb10c8eb36a0222d27e50fe381b86ce49a55446bf39f491727564/opencv_python-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:f90ba04b8f73bc5c3814037699739f0156f597338a98f05956c684e7c3ca10d2", size = 44000345, upload-time = "2026-07-02T05:49:54.971Z" },
-]
 
 [[package]]
 name = "opencv-python-headless"
@@ -1082,6 +1075,7 @@ dependencies = [
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
     { name = "invisible-watermark" },
+    { name = "opencv-python-headless" },
     { name = "peft" },
     { name = "pillow" },
     { name = "pillow-avif-plugin" },
@@ -1101,6 +1095,7 @@ requires-dist = [
     { name = "imageio" },
     { name = "imageio-ffmpeg" },
     { name = "invisible-watermark" },
+    { name = "opencv-python-headless" },
     { name = "peft" },
     { name = "pillow" },
     { name = "pillow-avif-plugin" },

--- a/docs/plan/2026-07-11_dockerfile-hadolint.md
+++ b/docs/plan/2026-07-11_dockerfile-hadolint.md
@@ -1,0 +1,83 @@
+# app/Dockerfile に hadolint を導入し、apt-get 自体を撤廃する
+
+## 背景・課題
+
+`app/Dockerfile` のセキュリティ向上のため hadolint を導入し、CI でチェックしたい。
+hadolint を実行したところ、警告は次の2件だった。
+
+- **DL3045** (L4): `WORKDIR` 未設定のまま相対パスへ `COPY`
+- **DL3008** (L5): `apt-get install` のパッケージバージョン未固定
+
+DL3008 は「バージョン固定 or ルール ignore」が定石だが、Debian はミラーから
+古いバージョンが消えるため固定はビルド破損のリスクが高く、ignore は警告の
+握りつぶしになる。そもそも **apt-get しないといけない状態を解消する** 方針とした。
+
+## 事前調査
+
+apt でインストールしていた4パッケージの必要性を調査した結果、すべて撤廃可能と判明。
+
+- `wget` / `git`: アプリコード（`app/*.py`, `cmd/*.py`）に使用箇所なし。
+  ダウンロードは `urllib.request.urlopen` と `huggingface_hub.snapshot_download` のみ。
+  `app/uv.lock` に git 依存もなし。
+- `libgl1-mesa-glx` / `libglib2.0-0`: 必要としているのは `invisible-watermark` が
+  依存する **`opencv-python`（GUI 版）だけ**。`controlnet-aux` は既に
+  `opencv-python-headless` を使用しており、GUI 版を headless に置き換えれば不要
+  （headless の manylinux wheel は必要な共有ライブラリを同梱している）。
+
+前提の裏付けとして、素の `python:3.14-slim`（apt パッケージ追加なし）で
+`opencv-python-headless` の `import cv2` が成功することを確認済み。
+
+## 変更内容
+
+### 1. `app/pyproject.toml` — opencv-python を headless に置換
+
+- `dependencies` に `opencv-python-headless` を追加
+- `[tool.uv]` の `override-dependencies` で GUI 版を解決から除外
+
+```toml
+override-dependencies = [
+  # Exclude the GUI build of opencv pulled in by invisible-watermark;
+  # opencv-python-headless provides cv2 instead.
+  "opencv-python; sys_platform == 'never'",
+]
+```
+
+`cd app && uv lock` で `app/uv.lock` を再生成（`opencv-python` は
+`sys_platform == 'never'` マーカー付きとなり、インストール対象から外れる）。
+
+### 2. `app/Dockerfile` — apt-get 撤廃 + WORKDIR 追加
+
+```dockerfile
+FROM python:3.14.6-slim-bookworm
+COPY --from=ghcr.io/astral-sh/uv:0.11.24 /uv /uvx /usr/local/bin/
+ENV UV_PROJECT_ENVIRONMENT=/usr/local
+WORKDIR /app
+COPY ./pyproject.toml ./uv.lock ./
+RUN uv sync --frozen --no-dev --no-cache
+```
+
+- apt-get の RUN 行が消えるため DL3008 は根本解消（`.hadolint.yaml` も不要）
+- `WORKDIR /app` で DL3045 を解消。パッケージは `UV_PROJECT_ENVIRONMENT=/usr/local`
+  によりシステム環境へ入るため、WORKDIR の場所は実行時に影響しない
+  （Modal は実行時に自前の workdir を設定する）
+
+### 3. `.github/workflows/docker_image_ci.yml` — hadolint ジョブ追加
+
+既存の `build` ジョブと並列に `hadolint` ジョブを追加（トリガー paths は現状のまま）。
+アクションは既存ワークフローのスタイルに合わせて commit SHA で固定
+（`hadolint/hadolint-action` v3.3.0）。
+
+## リスクとフォールバック
+
+- 万一実行環境で `import cv2` が失敗する場合は、`libglib2.0-0` のみ apt-get で残し、
+  その行に `# hadolint ignore=DL3008` のインラインコメントを付けるフォールバックを取る。
+
+## 検証
+
+1. `hadolint app/Dockerfile` → 警告ゼロ（確認済み）
+2. `docker run --rm --platform linux/amd64 python:3.14-slim` 上で
+   `pip install opencv-python-headless` → `import cv2` 成功（確認済み）
+3. `cd app && uv lock --check` でロックの整合確認（確認済み）
+4. フルビルドは torch cu126（x86_64 のみ・数 GB）のためローカルでは重い →
+   push 後に既存の Docker image CI（`docker build`）で検証
+   （paths トリガーに `app/Dockerfile`・`pyproject.toml`・`uv.lock` が含まれる）


### PR DESCRIPTION
## 実装経緯の説明

`app/Dockerfile` のセキュリティ向上のため hadolint を導入し、CI でチェックするようにした。導入時点の警告2件（DL3045 / DL3008）は、DL3008 の定石対応（バージョン固定 or ignore）ではなく、apt-get 自体を撤廃することで根本解消した。

詳細な経緯・調査結果は `docs/plan/2026-07-11_dockerfile-hadolint.md` を参照。

## 補足

### 主な変更内容

- `.github/workflows/docker_image_ci.yml`: `hadolint` ジョブを追加（`hadolint/hadolint-action` v3.3.0、既存スタイルに合わせて commit SHA 固定）
- `app/Dockerfile`: `WORKDIR /app` を追加（DL3045 解消）し、apt-get の RUN 行を削除（DL3008 根本解消）
- `app/pyproject.toml` / `app/uv.lock`: `opencv-python-headless` を直接依存に追加し、`invisible-watermark` が引き込む GUI 版 `opencv-python` を uv の `override-dependencies` で解決から除外

### 技術的な詳細

- apt でインストールしていた `wget` / `git` はコード内に使用箇所なし（ダウンロードは `urllib` と `huggingface_hub` のみ、git 依存もなし）
- `libgl1-mesa-glx` / `libglib2.0-0` は GUI 版 opencv-python だけが必要としていた。headless の manylinux wheel は必要な共有ライブラリを同梱するため apt パッケージ不要
- 素の `python:3.14-slim`（apt 追加なし）で `opencv-python-headless` の `import cv2` が成功することを検証済み

### 確認事項

- Docker image CI の `build` ジョブ（フルビルド）が通ること
- Modal 上で SDXL パイプライン実行時に `import cv2`（invisible-watermark / controlnet-aux 経由）がエラーにならないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)