### PR TITLE
chore: lint CIをuv経由にしてruffのバージョンをlockで固定

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -7,13 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Install Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
-          python-version: "3.14"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff
+          enable-cache: true
       - name: Run Ruff
-        run: ruff check --output-format=github .
+        run: uv run --frozen ruff check --output-format=github .

--- a/docs/plan/2026-07-12_lint-ci-uv-ruff.md
+++ b/docs/plan/2026-07-12_lint-ci-uv-ruff.md
@@ -1,0 +1,51 @@
+# lint CI の Python ハードコード撤廃と ruff のバージョン固定（PR #282）
+
+## 背景・課題
+
+mise 導入（バージョン管理とタスクランナーの一元化）を検討した結果、Python 1本の
+プロジェクトでは uv と役割が重複するため見送り、uv に寄せ切る方針とした。
+その検討過程で、バージョン管理の一元化ができていない箇所が2つ見つかった。
+
+1. **Python バージョンの不整合**: `lint_python.yml` が `python-version: "3.14"` を
+   ハードコードしている一方、root プロジェクトは `requires-python = ">=3.12"`。
+   なお app/ の `==3.14.*` は Docker ベースイメージとの厳密一致が必須な意図的設計
+   （2026-07-11_python-3.14-upgrade.md 参照）のため、不整合には該当しない
+2. **ruff のバージョンが未固定**: CI は `pip install ruff` で毎回最新を取得し、
+   pyproject の依存にも入っていないため、ローカルと CI で ruff の挙動が食い違い得る
+
+## 方針
+
+CI から Python バージョン指定を消し、ruff を root の dev 依存として uv.lock で
+固定する。バージョンの単一ソースは各 pyproject の `requires-python` になる。
+
+全体を 3.14 に統一する案（root の `requires-python` も上げる）は、root（modal CLI
+クライアント）に機能上の必要がなく、今後 app 側がバンプするたびに root も手動追随が
+必要になるため不採用とした。
+
+## 変更内容
+
+1. **ruff を root の dev 依存に追加**: `uv add --dev ruff` で
+   `[dependency-groups] dev` に追加し、uv.lock で `0.15.21` に固定。
+   dependabot は uv ecosystem（directory "/"）を監視済みのため、以後の更新は
+   自動で PR が来る
+2. **`.github/workflows/lint_python.yml` を uv 経由に書き換え**:
+   `actions/setup-python`（3.14 ハードコード）+ `pip install ruff` を削除し、
+   `astral-sh/setup-uv`（リポジトリの慣例に合わせコミット SHA で pin、v8.3.2、
+   `enable-cache: true`）+ `uv run --frozen ruff check --output-format=github .`
+   に置き換え。lock どおりの ruff でローカルと CI が同条件になる
+
+## 検証
+
+- `uv lock --check` で lock と pyproject の整合を確認
+- `uv run --frozen ruff check --output-format=github --isolated .` が exit 0
+  （`--isolated` はリポジトリに ruff 設定ファイルが無い CI 相当の条件）
+- workflow YAML は prettier / actionlint パス
+- push 後、lint CI（`CI` workflow）がグリーンになることを確認済み
+
+## 運用メモ
+
+- ローカルに未トラックの `ruff.toml`（`lint.select=["ALL"]`）がある場合、CI
+  （設定ファイルなし = デフォルトルール）と lint 結果が食い違う。CI にも同じ
+  ルールを適用するなら `ruff.toml` のコミットと指摘の解消が別途必要
+- mise 再検討の条件: 複数言語のツールチェーンが増えたとき、またはチーム開発に
+  なったとき

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,8 @@ dependencies = [
     "pillow>=12.3.0",
     "python-dotenv>=1.2.2",
 ]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.15.21",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -1127,6 +1127,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1162,6 +1187,11 @@ dependencies = [
     { name = "python-dotenv" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "diffusers", specifier = ">=0.39.0" },
@@ -1170,6 +1200,9 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.15.21" }]
 
 [[package]]
 name = "synchronicity"


### PR DESCRIPTION
## 実装経緯の説明

mise導入を検討した際、バージョン管理の一元化ができていない箇所が2つ見つかった（mise自体は見送り、uvに寄せ切る方針で解決）。

1. lint CIがPython 3.14をハードコードしており、rootプロジェクト（requires-python >=3.12）とズレていた
2. ruffがCIで`pip install ruff`（毎回最新）で、pyprojectの依存にも入っておらず、ローカル/CI間で挙動が食い違い得た

## 補足

### 主な変更内容

- ruffをrootのdev依存に追加し、uv.lockで0.15.21に固定
- lint CIをsetup-python + pipからastral-sh/setup-uv + `uv run --frozen ruff check`に置き換え、CIからPythonバージョン指定を撤廃

### 技術的な詳細

- バージョンの単一ソースは各pyprojectの`requires-python`になる（CIはuvが解決）
- setup-uvはリポジトリの慣例に合わせコミットSHAでpin（v8.3.2）、`enable-cache: true`を設定
- dependabotは既にuv ecosystem（directory "/"）とgithub-actionsを監視しているため、ruff・setup-uvの更新は自動でPRが来る
- app/の`requires-python == 3.14.*`はDockerベースイメージとの厳密一致が前提の意図的設計（docs/plan/2026-07-11_python-3.14-upgrade.md）のため変更していない

### 確認事項

- lint CI（`CI` workflow）がグリーンになること
- `uv run --frozen ruff check --isolated .`（CI相当）はローカルでexit 0を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)